### PR TITLE
Add icon semantic guide

### DIFF
--- a/guides/crm-star/markup/base/icons.html
+++ b/guides/crm-star/markup/base/icons.html
@@ -1,0 +1,74 @@
+<table class="table" id="crm-icon-table">
+  <thead>
+    <tr>
+      <th>Icon</th>
+      <th>Used For</th>
+      <th>Icon</th>
+      <th>Used For</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><i class="crm-i fa-user"></i></td><td>Individual</td>
+      <td><i class="crm-i fa-home"></i></td><td>Household</td>
+    </tr>
+    <tr>
+      <td><i class="crm-i fa-building"></i></td><td>Organization</td>
+      <td><i class="crm-i fa-users"></i></td><td>Group</td>
+    </tr>
+    <tr>
+      <td><i class="crm-i fa-files-o"></i></td><td>Files</td>
+      <td><i class="crm-i fa-credit-card"></i></td><td>Contribution</td>
+    </tr>
+    <tr>
+      <td><i class="crm-i fa-paper-plane"></i></td><td>Pledge</td>
+      <td><i class="crm-i fa-id-badge"></i></td><td>Membership</td>
+    </tr>
+    <tr>
+      <td><i class="crm-i fa-calendar"></i></td><td>Event</td>
+      <td><i class="crm-i fa-ticket"></i></td><td>Participant</td>
+    </tr>
+    <tr>
+      <td><i class="crm-i fa-folder-open"></i></td><td>Case</td>
+      <td><i class="crm-i fa-bullhorn"></i></td><td>Campaign</td>
+    </tr>
+    <tr>
+      <td><i class="crm-i fa-money"></i></td><td>Grant</td>
+      <td><i class="crm-i fa-tasks"></i></td><td>Activity</td>
+    </tr>
+    <tr>
+      <td><i class="crm-i fa-sticky-note"></i></td><td>Note</td>
+      <td><i class="crm-i fa-tag"></i></td><td>Tag</td>
+    </tr>
+    <tr>
+      <td><i class="crm-i fa-envelope"></i></td><td>Mailing</td>
+      <td><i class="crm-i fa-handshake-o"></i></td><td>Relationship</td>
+    </tr>
+    <tr>
+      <td><i class="crm-i fa-bar-chart"></i></td><td>Report</td>
+      <td><i class="crm-i fa-gears"></i></td><td>Administer</td>
+    </tr>
+    <tr>
+      <td><i class="crm-i fa-wrench"></i></td><td>Configure</td>
+      <td><i class="crm-i fa-gear"></i></td><td>Custom data / fields</td>
+    </tr>
+    <tr>
+      <td><i class="crm-i fa-history"></i></td><td>Change log / Recent items</td>
+      <td><i class="crm-i fa-life-ring"></i></td><td>Support</td>
+    </tr>
+    <tr>
+      <td><i class="crm-i fa-question-circle"></i></td><td>Help</td></tr>
+  </tbody>
+</table>
+<style>
+  /* Display icon classes on screen */
+  #crm-icon-table td:hover i:after {
+    content: " " attr(class);
+    color: darkgrey;
+  }
+  #crm-icon-table td:first-child,
+  #crm-icon-table td:nth-child(3) {
+    width: 13em;
+    padding-right: 0!important;
+  }
+</style>


### PR DESCRIPTION
Adds the following guide to canonize icons in CiviCRM.

![screenshot from 2018-10-29 08-46-33](https://user-images.githubusercontent.com/2874912/47650666-533dd900-db57-11e8-949e-74c30f1e629e.png)


