### PR TITLE
Update call to deprecated Smarty::get_template_vars

### DIFF
--- a/templates/CRM/StyleGuide/Page/StyleGuide.tpl
+++ b/templates/CRM/StyleGuide/Page/StyleGuide.tpl
@@ -1,5 +1,5 @@
 {php}
-  $htmlBuilder = new CRM_StyleGuide_HtmlBuilder($this->get_template_vars('styleguide'));
+  $htmlBuilder = new CRM_StyleGuide_HtmlBuilder($this->getTemplateVars('styleguide'));
 {/php}
 <section id="bootstrap-theme">
   <!-- <div class="navbar navbar-default navbar-fixed-top" role="navigation">


### PR DESCRIPTION
Replaces deprecated function name with the forward-compat equivalent.

Note: the new getTemplateVars function has been available since CiviCRM 5.70.